### PR TITLE
[faq] Add FAQ entry on locking notes against accidental edits

### DIFF
--- a/docs/content/faq/note_lock.md
+++ b/docs/content/faq/note_lock.md
@@ -1,0 +1,22 @@
+---
+title: 'How do I protect a note from accidental edits?'
+date: 2026-08-18T00:00:00-00:00
+draft: false
+weight: 4
+---
+
+Page Notes can lock a note so that it stays visible but can't be edited until you unlock it. This is useful for notes you refer to often and don't want to change by mistake.
+
+Locking is off by default. To turn it on, open the Page Notes options page, click "Advanced Settings" near the bottom of the Settings card, and enable "Allow locking notes".
+
+Once it's enabled, a lock button appears next to the Edit button when you view a note in the popup or the side panel:
+
+- An **open lock** means the note is editable. Click it to lock the note.
+- An **amber closed lock** means the note is locked. The Edit button is greyed out and clicking the note no longer starts an edit. Click the lock again to unlock it.
+
+A few things worth knowing:
+
+- The lock is stored with the note, so it syncs to your other devices along with everything else.
+- On the All Notes page, locked notes show a disabled Edit button. Unlocking is done from the note popup or side panel. Deleting a note is not blocked by the lock.
+- Locking is not encryption. A locked note is stored the same way as any other note; it's only protected from accidental edits. If you want a note to be unreadable without a passphrase, use the encryption option instead.
+- Turning the "Allow locking notes" option back off simply hides the lock UI and lets you edit everything again. Your notes keep their lock flags, so they come back locked if you turn the option on again.


### PR DESCRIPTION
## Summary
Adds a FAQ entry for the per-note read-only lock: how to turn the option on, what the lock button does, and what the lock does and doesn't cover.

The extension side (manugarg/pagenotes#129) moves "Allow locking notes" behind Advanced Settings and links here from the option's description, so the detail lives in one place instead of in a long settings blurb.

Renders at `https://pagenotes.manugarg.com/faq/#note_lock`, which is the anchor the options page links to.

## Test plan
- Built the site with the vendored Hugo: the entry renders in the FAQ list and lands on the `#note_lock` anchor.

Worth landing around the same time as manugarg/pagenotes#129 — until this deploys, the "Learn more" link in the options page just opens the top of the FAQ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pq883SnXASLhnvQsqVZ11M
