### PR TITLE
[faq] Say what the note lock actually covers

### DIFF
--- a/docs/content/faq/note_lock.md
+++ b/docs/content/faq/note_lock.md
@@ -5,7 +5,7 @@ draft: false
 weight: 4
 ---
 
-Page Notes can lock a note so that it stays visible but can't be edited until you unlock it. This is useful for notes you refer to often and don't want to change by mistake.
+Page Notes can lock a note so that it stays visible but can't be edited until you unlock it. It's meant for notes you open and read often and don't want to change by mistake — an address, a set of credentials-adjacent details, a reference you keep coming back to.
 
 Locking is off by default. To turn it on, open the Page Notes options page, click "Advanced Settings" near the bottom of the Settings card, and enable "Allow locking notes".
 
@@ -16,7 +16,7 @@ Once it's enabled, a lock button appears next to the Edit button when you view a
 
 A few things worth knowing:
 
-- The lock is stored with the note, so it syncs to your other devices along with everything else.
-- On the All Notes page, locked notes show a disabled Edit button. Unlocking is done from the note popup or side panel. Deleting a note is not blocked by the lock.
-- Locking is not encryption. A locked note is stored the same way as any other note; it's only protected from accidental edits. If you want a note to be unreadable without a passphrase, use the encryption option instead.
-- Turning the "Allow locking notes" option back off simply hides the lock UI and lets you edit everything again. Your notes keep their lock flags, so they come back locked if you turn the option on again.
+- The lock travels with the note, so it syncs to your other devices. If a locked note arrives on a device where you have never touched this setting, Page Notes turns the setting on there for you so the lock is honoured rather than silently ignored.
+- The lock guards the popup and the side panel, which is where notes are normally read and edited. The All Notes page is the management view you go to deliberately, so it doesn't block anything there — you can edit and delete as usual, and editing a locked note there keeps its lock rather than removing it. The web app at pagenotes.app doesn't enforce the lock either.
+- Locking is not encryption, and it is not a security feature. A locked note is stored exactly like any other note — the lock only stops an accidental edit. If you want a note to be unreadable without a passphrase, use the encryption option instead.
+- Turning the setting back off hides the lock UI and lets you edit everything again. Your notes keep their lock flags, so they come back locked if you turn it on again.


### PR DESCRIPTION
## Summary
Follow-up to #128. The entry described the lock more broadly than the extension actually behaves, and the behaviour itself has since narrowed.

- Framed around what the feature is for: preventing an accidental edit, not securing a note. Says outright that it isn't a security feature and points at encryption for that.
- Scope corrected: the lock guards the popup and the side panel. All Notes no longer enforces it at all (manugarg/pagenotes#129) — you can edit and delete there as usual, and editing keeps the lock rather than clearing it. The web app at pagenotes.app doesn't enforce it either.
- Documents the new cross-device behaviour: a locked note arriving on a device where the setting was never touched turns the setting on there, so the lock is honoured instead of silently ignored.

## Test plan
- Built the site with the vendored Hugo; the entry renders on the `#note_lock` anchor that the extension's options page links to.

Pairs with manugarg/pagenotes#129, which is where the behaviour changes live.
